### PR TITLE
Externalizar variáveis para a Oauth com google

### DIFF
--- a/internal/controller/oauth2.go
+++ b/internal/controller/oauth2.go
@@ -19,6 +19,7 @@ type Config struct {
 	ClientId     string `env:"GOOGLE_CLIENT_ID,required"`
 	ClientSecret string `env:"GOOGLE_CLIENT_SECRET,required"`
 	OAuthSecret  string `env:"OAUTH_SECRET,required"`
+	RedirectURL  string `env:"REDIRECT_URL,required" envDefault:"http://localhost:8080/callback"`
 }
 
 type Oauth2Client struct {
@@ -103,7 +104,7 @@ func Oauth2(repository *repository.CustomerRepository) *Oauth2Client {
 			ClientID:     config.ClientId,
 			ClientSecret: config.ClientSecret,
 			Endpoint:     google.Endpoint,
-			RedirectURL:  "http://localhost:8080/callback",
+			RedirectURL:  config.RedirectURL,
 			Scopes:       []string{"https://www.googleapis.com/auth/userinfo.email", "https://www.googleapis.com/auth/userinfo.profile"},
 		}, config, repository,
 	}

--- a/internal/repository/customer_test.go
+++ b/internal/repository/customer_test.go
@@ -3,19 +3,9 @@ package repository
 import (
 	"context"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"os"
 	"testing"
 	"time"
 )
-
-func init() {
-	_ = os.Setenv("DATABASE_URI", "mongodb://localhost:27017")
-	_ = os.Setenv("DATABASE_NAME", "customers")
-	_ = os.Setenv("DATABASE_COLLECTION", "customers")
-	_ = os.Setenv("DATABASE_TIMEOUT", "1s")
-	_ = os.Setenv("DATABASE_PASSWORD", "password")
-	_ = os.Setenv("DATABASE_USER", "user")
-}
 
 func TestCustomerController_Create(t *testing.T) {
 	created := time.Now()


### PR DESCRIPTION
Nesse pull request foi externalizada somente a variável de redirect, as de scope serão feitas dada a necessidade.

Como vamos seguir com escopo somente de perfil do usuário, não foi necessário externalizar isso agora principalmente pois a demanda de adicionar um novo scope também irá influenciar em desenvolvimento na alteração da estrutura que retorna do callback.